### PR TITLE
Feature/orrego diego

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,16 @@ build: tools
 	fi
 	@# Ejecutar script de resolución DNS
 	@echo "Ejecutando resolución DNS..."
-	@DOMAINS_FILE=$(DOMAINS_FILE) DNS_SERVER=$(DNS_SERVER) $(SRC_DIR)/resolve_dns.sh
+	@DOMAINS_FILE=$(DOMAINS_FILE) DNS_SERVER=$(DNS_SERVER) $(SRC_DIR)/resolve_dns.sh || { \
+		echo "ADVERTENCIA: resolve_dns.sh retornó código $$?"; \
+		echo "Verificando si se generaron artefactos..."; \
+		if [ -f "$(OUT_DIR)/dns_resolves.csv" ]; then \
+			echo "CSV generado, continuando..."; \
+		else \
+			echo "ERROR: No se generó CSV"; \
+			exit 1; \
+		fi; \
+	}
 	@echo ""
 	@echo "==================================================================="
 	@echo "Build completado. Artefactos generados en $(OUT_DIR)/"


### PR DESCRIPTION
## ¿Qué se hizo?

  Reforcé el target build del Makefile para garantizar la correcta separación Configurar-Lanzar-Ejecutar (C-L-E) según 12-Factor I y V.
  Implementé manejo robusto de errores que valida la generación de artefactos en out/ antes de fallar, permitiendo que el build funcione incluso con resoluciones DNS parciales. Documenté todas las evidencias técnicas en la bitácora Sprint 1 con comandos ejecutados, salidas y decisiones de diseño.

  ## ¿Por qué se hizo?

  Según la guía del Día 2, mi responsabilidad es demostrar que el target build NO ejecuta el pipeline completo, sino que solo genera artefactos intermedios en out/. Esta separación es crítica para cumplir con la metodología 12-Factor (principios I: Codebase y V: Build/Release/Run) y facilitar el desarrollo iterativo sin reejecutar todo el flujo en cada cambio.

  ## ¿Cómo se implementó?

  Modifiqué el target build del Makefile para incluir validación de artefactos generados con manejo de errores graceful. Si resolve_dns.sh falla pero genera el CSV, el build continúa con advertencia. Si no genera ningún artefacto, falla apropiadamente. La separación queda clara: build solo ejecuta resolución DNS, mientras que run ejecutará el flujo completo (que incluirá construcción de grafo y verificación de conectividad en sprints 2-3).

  ## Evidencia

  # Salida de make help mostrando separación clara
  make tools      # Verifica herramientas (código 0)
  make build      # Solo genera out/dns_resolves.csv
  make run        # Mensaje: "Próximos pasos (sprints 2-3): construcción de grafo..."

  Fragmento del Makefile modificado:
```
  @DOMAINS_FILE=$(DOMAINS_FILE) DNS_SERVER=$(DNS_SERVER) $(SRC_DIR)/resolve_dns.sh || { \
      echo "ADVERTENCIA: resolve_dns.sh retornó código $$?"; \
      echo "Verificando si se generaron artefactos..."; \
      if [ -f "$(OUT_DIR)/dns_resolves.csv" ]; then \
          echo "CSV generado, continuando..."; \
      else \
          echo "ERROR: No se generó CSV"; \
          exit 1; \
      fi; \
  }
```
  Documentación completa en docs/bitacora-sprint-1.md sección "Diego Orrego (Día 2)".

  ## Checklist de Revisión

  - Tests pasan correctamente (N/A para Makefile, responsabilidad de Melissa)
  - Documentación actualizada (bitácora Sprint 1 con evidencias completas)
  - Sin warnings en el código (Makefile validado con make -n)
  - Variables de entorno documentadas (tabla en README.md del día 1)
  - Makefile targets funcionan (tools, build, run, clean verificados)