### PR TITLE
Implementar detección de ciclos CNAME y bitácora día 4

### DIFF
--- a/out/cycles_report.txt
+++ b/out/cycles_report.txt
@@ -1,0 +1,22 @@
+===================================================================
+Reporte de Detección de Ciclos DNS
+===================================================================
+
+Generado: 2025-10-02 23:33:49
+Entrada: out/edges.csv
+
+Análisis de cadenas CNAME:
+
+
+CYCLE DETECTADO:
+  Nodos involucrados: loop2.example.com loop1.example.com loop2.example.com
+  Inicio del ciclo: loop2.example.com
+
+CYCLE DETECTADO:
+  Nodos involucrados: loop2.example.com loop1.example.com loop1.example.com
+  Inicio del ciclo: loop1.example.com
+
+Estado: CICLOS ENCONTRADOS (2)
+Acción recomendada: Revisar configuración DNS
+
+===================================================================

--- a/out/depth_report.txt
+++ b/out/depth_report.txt
@@ -2,13 +2,13 @@
 Reporte de Profundidad del Grafo DNS
 ===================================================================
 
-Generado: 2025-10-01 22:10:51
+Generado: 2025-10-02 23:33:49
 Entrada: out/dns_resolves.csv
 
 Métricas:
-  - Cadenas analizadas: 7
-  - Profundidad máxima: 6
-  - Profundidad promedio: 3.14
+  - Cadenas analizadas: 3
+  - Profundidad máxima: 2
+  - Profundidad promedio: 1.33
 
 Definición:
   Profundidad = número de saltos desde dominio origen hasta registro A final

--- a/out/dns_resolves.csv
+++ b/out/dns_resolves.csv
@@ -1,8 +1,7 @@
 source,record_type,target,ttl,trace_ts
 google.com,A,142.250.0.113,50,1759195656
 google.com,A,142.250.0.102,50,1759195656
-google.com,A,142.250.0.101,50,1759195656
-google.com,A,142.250.0.138,50,1759195656
-google.com,A,142.250.0.139,50,1759195656
-google.com,A,142.250.0.100,50,1759195656
+loop1.example.com,CNAME,loop2.example.com,300,1759195658
+loop2.example.com,CNAME,loop1.example.com,300,1759195659
 github.com,A,4.228.31.150,34,1759195682
+www.github.com,CNAME,github.com,3600,1759195661

--- a/out/edges.csv
+++ b/out/edges.csv
@@ -1,8 +1,7 @@
 from,to,kind
 google.com,142.250.0.113,A
 google.com,142.250.0.102,A
-google.com,142.250.0.101,A
-google.com,142.250.0.138,A
-google.com,142.250.0.139,A
-google.com,142.250.0.100,A
+loop1.example.com,loop2.example.com,CNAME
+loop2.example.com,loop1.example.com,CNAME
 github.com,4.228.31.150,A
+www.github.com,github.com,CNAME


### PR DESCRIPTION
## ¿Qué se hizo?
Implementé la detección de ciclos en cadenas CNAME dentro de `build_graph.sh` para identificar bucles infinitos que podrían causar problemas de resolución DNS. El sistema ahora genera un reporte completo de ciclos detectados. Los cambios incluyen la implementación de la función `detect_cycles()` con algoritmo "visited tracking", la generación de `out/cycles_report.txt` con palabra clave "CYCLE", la integración de la detección como Paso 4 en el flujo de `build_graph.sh`, la adición de datos de prueba con ciclo CNAME para validación, y la documentación completa de la implementación en bitácora Sprint 2 día 4.

## ¿Por qué se hizo?
Según la guía Sprint 2 día 4, necesitábamos implementar detección de ciclos para identificar bucles infinitos en cadenas CNAME como loop1 → loop2 → loop1, generar reportes con palabra clave "CYCLE" para validación automática, y prevenir problemas de resolución DNS en configuraciones incorrectas. Esta funcionalidad es crítica para detectar configuraciones DNS problemáticas que podrían causar resoluciones infinitas y afectar el rendimiento del sistema.

## ¿Cómo se implementó?
El algoritmo de detección funciona extrayendo solo aristas CNAME del grafo usando `awk -F',' 'NR > 1 && $3 == "CNAME"`, luego para cada nodo origen sigue la cadena hasta encontrar un nodo ya visitado (indicando un ciclo). Implementé un límite de seguridad de máximo 10 saltos para prevenir bucles infinitos y genero un reporte con formato estructurado que incluye nodos involucrados y recomendaciones. La integración se realizó añadiendo la detección como Paso 4 después de calcular profundidad, conservando todas las funcionalidades existentes como edges.csv y depth_report.txt, mientras mantengo la separación C-L-E ya que no consulta red, solo post-procesa CSV.
